### PR TITLE
calling erlang:nif_error when nif is not loaded

### DIFF
--- a/src/ua_classifier.erl
+++ b/src/ua_classifier.erl
@@ -61,15 +61,15 @@ init() ->
 
 
 %% @doc Check a user-agent string against the OpenDDR classifications.
--spec classify( UserAgentString :: iolist() ) -> {ok, Properties :: list()} | {error, Reason :: term() }.
+-spec classify( UserAgentString :: iolist() ) -> {ok, Properties :: list()} | no_return().
 classify(_UserAgent) ->
-    {error, ua_classifier_nif_not_loaded}.
+    erlang:nif_error(ua_classifier_nif_not_loaded).
 
 
 %% @doc Check a user-agent string against the OpenDDR Browser classifications.
--spec browser_classify( UserAgentString :: iolist() ) -> {ok, Properties :: list()} | {error, Reason :: term() }.
+-spec browser_classify( UserAgentString :: iolist() ) -> {ok, Properties :: list()} | no_return().
 browser_classify(_UserAgent) ->
-    {error, ua_classifier_nif_not_loaded}.
+    erlang:nif_error(ua_classifier_nif_not_loaded).
 
 
 %% @doc Map a list of user-agent properties (as returned by classify/1) to a simple device type atom.

--- a/src/ua_classifier.erl
+++ b/src/ua_classifier.erl
@@ -61,13 +61,13 @@ init() ->
 
 
 %% @doc Check a user-agent string against the OpenDDR classifications.
--spec classify( UserAgentString :: iolist() ) -> {ok, Properties :: list()} | no_return().
+-spec classify( UserAgentString :: iodata() ) -> {ok, Properties :: list()} | no_return().
 classify(_UserAgent) ->
     erlang:nif_error(ua_classifier_nif_not_loaded).
 
 
 %% @doc Check a user-agent string against the OpenDDR Browser classifications.
--spec browser_classify( UserAgentString :: iolist() ) -> {ok, Properties :: list()} | no_return().
+-spec browser_classify( UserAgentString :: iodata() ) -> {ok, Properties :: list()} | no_return().
 browser_classify(_UserAgent) ->
     erlang:nif_error(ua_classifier_nif_not_loaded).
 


### PR DESCRIPTION
This PR calls erlang:nif_error(Reason) when nif is not loaded, so that Dialyzer does not generate false warnings.

More details on erlang:nif_error -> http://erlang.org/doc/man/erlang.html#nif_error-1